### PR TITLE
Remove Leftover Ubuntu Xenial Items

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -50,15 +50,6 @@ def test_debian_9_packages(host, pkg):
         assert host.package(pkg).is_installed
 
 
-@pytest.mark.parametrize("pkg", ["openjdk-8-jdk"])
-def test_ubuntu_xenial_packages(host, pkg):
-    """Test that the appropriate packages were installed."""
-    distribution = host.system_info.distribution
-    codename = host.system_info.codename
-    if distribution == "ubuntu" and codename == "xenial":
-        assert host.package(pkg).is_installed
-
-
 @pytest.mark.parametrize("pkg", ["java-11-openjdk-devel"])
 def test_redhat_packages(host, pkg):
     """Test that the appropriate packages were installed."""

--- a/vars/Ubuntu_xenial.yml
+++ b/vars/Ubuntu_xenial.yml
@@ -1,7 +1,0 @@
----
-# vars file for Ubuntu Xenial
-
-# The packages to install for OpenJDK.  OpenJDK 9 does not install
-# cleanly on Xenial, so we have to revert to using OpenJDK 8.
-package_names:
-  - openjdk-8-jdk


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR removes some dangling items related to Ubuntu Xenial. This includes an Ubuntu Xenial specific `vars` file and Ubuntu Xenial specific testing.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Support for Ubuntu Xenial was removed in https://github.com/cisagov/ansible-role-openjdk/pull/14, but these files were missed during review. Since we neither support this platform nor test against it these items are no longer necessary and should be removed.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
