### PR TITLE
Fix failure to install OpenJDK on Debian Bookworm

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @jsf9k
+* @dav3r @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -32,35 +32,20 @@ def test_man_dirs(host, d):
         assert host.file(d).exists
 
 
-@pytest.mark.parametrize("pkg", ["openjdk-11-jdk"])
-def test_debian_packages(host, pkg):
+def test_packages(host):
     """Test that the appropriate packages were installed."""
     distribution = host.system_info.distribution
     codename = host.system_info.codename
-    if distribution == "debian" and codename != "stretch":
-        assert host.package(pkg).is_installed
-
-
-@pytest.mark.parametrize("pkg", ["openjdk-8-jdk"])
-def test_debian_9_packages(host, pkg):
-    """Test that the appropriate packages were installed."""
-    distribution = host.system_info.distribution
-    codename = host.system_info.codename
-    if distribution == "debian" and codename == "stretch":
-        assert host.package(pkg).is_installed
-
-
-@pytest.mark.parametrize("pkg", ["java-11-openjdk-devel"])
-def test_redhat_packages(host, pkg):
-    """Test that the appropriate packages were installed."""
-    distribution = host.system_info.distribution
-    if distribution == "fedora":
-        assert host.package(pkg).is_installed
-
-
-@pytest.mark.parametrize("pkg", ["java-1.8.0-openjdk-devel"])
-def test_amazon_packages(host, pkg):
-    """Test that the appropriate packages were installed."""
-    distribution = host.system_info.distribution
-    if distribution == "amzn":
-        assert host.package(pkg).is_installed
+    if distribution in ["debian", "kali", "ubuntu"]:
+        if codename in ["stretch"]:
+            assert host.package("openjdk-8-jdk").is_installed
+        elif codename in ["bookworm"]:
+            assert host.package("openjdk-17-jdk").is_installed
+        else:
+            assert host.package("openjdk-11-jdk").is_installed
+    elif distribution in ["fedora"]:
+        assert host.package("java-11-openjdk-devel").is_installed
+    elif distribution in ["amzn"]:
+        assert host.package("java-1.8.0-openjdk-devel").is_installed
+    else:
+        assert False, f"Unknown distribution: {distribution}"

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for Amazon Linux
-
 # The packages to install for OpenJDK
 package_names:
   - java-1.8.0-openjdk-devel

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for Debian
-
 # The packages to install for OpenJDK
 package_names:
   - openjdk-11-jdk

--- a/vars/Debian_bookworm.yml
+++ b/vars/Debian_bookworm.yml
@@ -1,0 +1,4 @@
+---
+# The packages to install for OpenJDK
+package_names:
+  - openjdk-17-jdk

--- a/vars/Debian_stretch.yml
+++ b/vars/Debian_stretch.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for Debian 9
-
 # The packages to install for OpenJDK
 package_names:
   - openjdk-8-jdk

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,4 @@
 ---
-# vars file for RedHat
-
 # The packages to install for OpenJDK
 package_names:
   - java-11-openjdk-devel


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Fixes this Ansible role's failure to install OpenJDK on Debian Bookworm.
- Restructures the Molecule test code that checks what OpenJDK packages were installed.  The new structure will fail if a new Linux distribution is added, whereas the previous structure would silently pass in this case.

## 💭 Motivation and context ##

Resolves #38.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.