### PR TITLE
Use FQCNs everywhere

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,7 +29,6 @@ galaxy_info:
         - bookworm
     - name: Fedora
       versions:
-        - "35"
         - "36"
         - "37"
     - name: Ubuntu

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -35,9 +35,6 @@ platforms:
   - image: kalilinux/kali-rolling
     name: kali
     platform: amd64
-  - image: fedora:35
-    name: fedora35
-    platform: amd64
   - image: fedora:36
     name: fedora36
     platform: amd64

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -71,15 +71,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: geerlingguy/docker-fedora35-ansible:latest
-    name: fedora35-systemd
-    platform: amd64
-    pre_build_image: yes
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
     image: geerlingguy/docker-fedora36-ansible:latest
     name: fedora36-systemd
     platform: amd64

--- a/tasks/add_missing_man_dirs.yml
+++ b/tasks/add_missing_man_dirs.yml
@@ -1,8 +1,6 @@
 ---
-# tasks file for openjdk
-
 - name: Create /usr/share/man/man[1-8] subdirectories if necessary
-  file:
+  ansible.builtin.file:
     path: /usr/share/man/man{{ item }}
     mode: 0755
     state: directory

--- a/tasks/add_missing_man_dirs.yml
+++ b/tasks/add_missing_man_dirs.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create /usr/share/man/man[1-8] subdirectories if necessary
   ansible.builtin.file:
-    path: /usr/share/man/man{{ item }}
     mode: 0755
+    path: /usr/share/man/man{{ item }}
     state: directory
   loop: "{{ range(1, 9) | list }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
-# tasks file for openjdk
-
 - name: Load var file with package names based on the OS type
-  include_vars: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
@@ -16,10 +14,10 @@
 # /usr/share/man/man[1-8] directories, which causes some packages
 # (including openjdk-jdk) to fail to install.
 - name: Add missing man directories if necessary
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: add_missing_man_dirs.yml
   when: ansible_distribution == "Debian"
 
 - name: Install OpenJDK
-  package:
+  ansible.builtin.package:
     name: "{{ package_names }}"


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to use FQCNs everywhere.

## 💭 Motivation and context ##

FQCNs are the way forward, and we use them in most of our other Ansible roles.  This one somehow fell through the cracks.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.