### PR TITLE
Configure alternatives for Kali Linux

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -2,6 +2,7 @@
 
 # Standard Python Libraries
 import os
+import pathlib
 
 # Third-Party Libraries
 import pytest
@@ -30,6 +31,160 @@ def test_man_dirs(host, d):
     distribution = host.system_info.distribution
     if distribution == "debian":
         assert host.file(d).exists
+
+
+@pytest.mark.parametrize(
+    "d, tool",
+    [
+        (
+            "bin",
+            "jaotc",
+        ),
+        (
+            "bin",
+            "jar",
+        ),
+        (
+            "bin",
+            "jarsigner",
+        ),
+        (
+            "bin",
+            "java",
+        ),
+        (
+            "bin",
+            "javac",
+        ),
+        (
+            "bin",
+            "javadoc",
+        ),
+        (
+            "bin",
+            "javap",
+        ),
+        (
+            "bin",
+            "jcmd",
+        ),
+        (
+            "bin",
+            "jconsole",
+        ),
+        (
+            "bin",
+            "jdb",
+        ),
+        (
+            "bin",
+            "jdeprscan",
+        ),
+        (
+            "bin",
+            "jdeps",
+        ),
+        (
+            "lib",
+            "jexec",
+        ),
+        (
+            "bin",
+            "jfr",
+        ),
+        (
+            "bin",
+            "jhsdb",
+        ),
+        (
+            "bin",
+            "jimage",
+        ),
+        (
+            "bin",
+            "jinfo",
+        ),
+        (
+            "bin",
+            "jjs",
+        ),
+        (
+            "bin",
+            "jlink",
+        ),
+        (
+            "bin",
+            "jmap",
+        ),
+        (
+            "bin",
+            "jmod",
+        ),
+        (
+            "bin",
+            "jps",
+        ),
+        (
+            "bin",
+            "jrunscript",
+        ),
+        (
+            "bin",
+            "jshell",
+        ),
+        (
+            "bin",
+            "jstack",
+        ),
+        (
+            "bin",
+            "jstat",
+        ),
+        (
+            "bin",
+            "jstatd",
+        ),
+        (
+            "bin",
+            "keytool",
+        ),
+        (
+            "bin",
+            "pack200",
+        ),
+        (
+            "bin",
+            "rmic",
+        ),
+        (
+            "bin",
+            "rmid",
+        ),
+        (
+            "bin",
+            "rmiregistry",
+        ),
+        (
+            "bin",
+            "serialver",
+        ),
+        (
+            "bin",
+            "unpack200",
+        ),
+    ],
+)
+def test_alternatives(host, d, tool):
+    """Test that the alternatives are configured as expected for Kali instances."""
+    distribution = host.system_info.distribution
+    if distribution == "kali":
+        alternative_path = str(pathlib.PurePath("/etc/alternatives", tool))
+        f = host.file(alternative_path)
+        assert f.exists
+        assert f.is_symlink
+        assert f.linked_to == str(
+            pathlib.PurePath("/usr/lib/jvm/java-11-openjdk-amd64", d, tool)
+        )
 
 
 def test_packages(host):

--- a/tasks/configure_alternatives.yml
+++ b/tasks/configure_alternatives.yml
@@ -1,4 +1,9 @@
 ---
+# This list of alternatives is generated via the following instructions:
+# 1. Install OpenJDK 11
+# 2. Run update-alternatives --get-selections
+# 3. Examine the output of the previous command and note which
+# selections point to files installed as part of OpenJDK.
 - name: Configure all alternatives for OpenJDK 11
   community.general.alternatives:
     name: "{{ item.tool }}"

--- a/tasks/configure_alternatives.yml
+++ b/tasks/configure_alternatives.yml
@@ -1,0 +1,74 @@
+---
+- name: Configure all alternatives for OpenJDK 11
+  community.general.alternatives:
+    name: "{{ item.tool }}"
+    path: /usr/lib/jvm/java-11-openjdk-amd64/{{ item.dir }}/{{ item.tool }}
+  loop:
+    - dir: bin
+      tool: jaotc
+    - dir: bin
+      tool: jar
+    - dir: bin
+      tool: jarsigner
+    - dir: bin
+      tool: java
+    - dir: bin
+      tool: javac
+    - dir: bin
+      tool: javadoc
+    - dir: bin
+      tool: javap
+    - dir: bin
+      tool: jcmd
+    - dir: bin
+      tool: jconsole
+    - dir: bin
+      tool: jdb
+    - dir: bin
+      tool: jdeprscan
+    - dir: bin
+      tool: jdeps
+    - dir: lib
+      tool: jexec
+    - dir: bin
+      tool: jfr
+    - dir: bin
+      tool: jhsdb
+    - dir: bin
+      tool: jimage
+    - dir: bin
+      tool: jinfo
+    - dir: bin
+      tool: jjs
+    - dir: bin
+      tool: jlink
+    - dir: bin
+      tool: jmap
+    - dir: bin
+      tool: jmod
+    - dir: bin
+      tool: jps
+    - dir: bin
+      tool: jrunscript
+    - dir: bin
+      tool: jshell
+    - dir: bin
+      tool: jstack
+    - dir: bin
+      tool: jstat
+    - dir: bin
+      tool: jstatd
+    - dir: bin
+      tool: keytool
+    - dir: bin
+      tool: pack200
+    - dir: bin
+      tool: rmic
+    - dir: bin
+      tool: rmid
+    - dir: bin
+      tool: rmiregistry
+    - dir: bin
+      tool: serialver
+    - dir: bin
+      tool: unpack200

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 # The debian:<release>-slim Docker images are missing the
 # /usr/share/man/man[1-8] directories, which causes some packages
 # (including openjdk-jdk) to fail to install.
-- name: Add missing man directories if necessary
+- name: Add missing man directories for Debian
   ansible.builtin.include_tasks:
     file: add_missing_man_dirs.yml
   when: ansible_distribution == "Debian"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,3 +21,13 @@
 - name: Install OpenJDK
   ansible.builtin.package:
     name: "{{ package_names }}"
+
+# By default OpenJDK 17 is being used on Kali Linux.  Neo4j <5
+# requires OpenJDK 11.
+#
+# TODO: This block can be removed once we upgrade to Neo4j version 5,
+# as discussed in cisagov/kali-packer#136.
+- name: Configure alternatives for Kali
+  ansible.builtin.include_tasks:
+    file: configure_alternatives.yml
+  when: ansible_distribution == "Kali"


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to configure alternatives for Kali Linux.

## 💭 Motivation and context ##

By default OpenJDK 17 is now used on Kali Linux.  Neo4j <5 requires OpenJDK 11, so we want to force it to be used.

See also cisagov/kali-packer#135.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.